### PR TITLE
CORCI-721 build: bugfix for jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
                         sh '''rm -rf artifacts/sles12.3/
                               mkdir -p artifacts/sles12.3/
                               make source
-                              cd _topdir/SOURCES; sudo build \
+                              sudo build \
                                 --repo http://cobbler/cobbler/ks_mirror/SLES-12.3-x86_64/suse \
                                 --repo http://cobbler/cobbler/repo_mirror/sdk-sles12.3-x86_64 \
                                 --repo http://cobbler/cobbler/repo_mirror/updates-sles12.3-x86_64 \
@@ -110,7 +110,7 @@ pipeline {
                         sh '''rm -rf artifacts/leap42.3/
                               mkdir -p artifacts/leap42.3/
                               make source
-                              cd _topdir/SOURCES; sudo build \
+                              sudo build \
                                 --repo http://download.opensuse.org/update/leap/42.3/oss/ \
                                 --repo http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/ \
                                 --dist sl42.3'''


### PR DESCRIPTION
The _topdir/SOURCES is not used for SUSE.

Signed-off-by: John.E.Malmberg <john.e.malmberg@intel.com>