### PR TITLE
CORCI-722 build: Fix building on SLES

### DIFF
--- a/Dockerfile.leap.42.3
+++ b/Dockerfile.leap.42.3
@@ -21,12 +21,11 @@ RUN zypper --non-interactive update
 
 # basic building
 ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"
-ENV TOOLS_42_3A="openSUSE:Tools/openSUSE_42.3/openSUSE:Tools.repo"
-ENV TOOLS_42_3="${OPENSUSE_REPO}/$(ENV_TOOLS_42_3A)"
+ENV TOOLS_42_3A="openSUSE:/Tools/openSUSE_42.3/openSUSE:Tools.repo"
+ENV TOOLS_42_3="${OPENSUSE_REPO}/${TOOLS_42_3A}"
 
-RUN zypper --non-interactive ar ${ENV_TOOLS_42_3A}; \
-    zypper --non-interactive --gpg-auto-import-keys ref \
-      'openSUSE.org tools (openSUSE_42.3)'
+RUN zypper --non-interactive ar ${TOOLS_42_3}; \
+    zypper --non-interactive --gpg-auto-import-keys refresh
 RUN zypper --non-interactive install autoconf automake build                 \
                                      ca-certificates-mozilla curl createrepo \
                                      git libtool lsb-release make            \
@@ -35,3 +34,15 @@ RUN zypper --non-interactive install autoconf automake build                 \
 
 # need to run the build command as root, as it needs to chroot
 RUN echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build
+
+# Suse build utility can not handle spaces in the repo aliases.
+ENV OPENSUSE_UPD="http://download.opensuse.org/update"
+ENV OPENSUSE_DIST="http://download.opensuse.org/distribution"
+RUN zypper --non-interactive nr 'NON OSS' NON_OSS; \
+    zypper --non-interactive nr 'NON OSS Update' NON_OSS_Update; \
+    zypper --non-interactive nr 'OSS Update' OSS_Update
+
+# Suse build utility needs this refresh.
+ARG CACHEBUST=1
+RUN zypper --non-interactive refresh; zypper lr --details
+

--- a/Dockerfile.leap.42.3
+++ b/Dockerfile.leap.42.3
@@ -36,13 +36,12 @@ RUN zypper --non-interactive install autoconf automake build                 \
 RUN echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build
 
 # Suse build utility can not handle spaces in the repo aliases.
-ENV OPENSUSE_UPD="http://download.opensuse.org/update"
-ENV OPENSUSE_DIST="http://download.opensuse.org/distribution"
 RUN zypper --non-interactive nr 'NON OSS' NON_OSS; \
     zypper --non-interactive nr 'NON OSS Update' NON_OSS_Update; \
     zypper --non-interactive nr 'OSS Update' OSS_Update
 
 # Suse build utility needs this refresh.
+# And the zypper lr report is handy to have.
 ARG CACHEBUST=1
 RUN zypper --non-interactive refresh; zypper lr --details
 

--- a/Dockerfile.sles.12.3
+++ b/Dockerfile.sles.12.3
@@ -21,12 +21,11 @@ RUN groupadd -g $UID $USER
 RUN zypper --non-interactive update
 # basic building
 ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"
-ENV TOOLS_12_3A="openSUSE:Tools/SLE_12_SP3/openSUSE:Tools.repo"
-ENV TOOLS_12_3="${OPENSUSE_REPO}/$(ENV_TOOLS_12_3A)"
+ENV TOOLS_12_3A="openSUSE:/Tools/SLE_12_SP3/openSUSE:Tools.repo"
+ENV TOOLS_12_3="${OPENSUSE_REPO}/${TOOLS_12_3A}"
 
-RUN zypper --non-interactive ar ${ENV_TOOLS_12_3}; \
-    zypper --non-interactive --gpg-auto-import-keys ref \
-      'openSUSE.org tools (SLE_12_SP3)'
+RUN zypper --non-interactive ar ${TOOLS_12_3}; \
+    zypper --non-interactive --gpg-auto-import-keys refresh
 RUN zypper --non-interactive install autoconf automake build                 \
                                      ca-certificates-mozilla curl createrepo \
                                      git libtool lsb-release make            \
@@ -36,3 +35,8 @@ RUN zypper --non-interactive install autoconf automake build                 \
 # need to run the build command as root, as it needs to chroot
 RUN echo "#includedir /etc/sudoers.d" >> /etc/sudoers; \
     echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build
+
+# Suse build utility needs this refresh.
+ARG CACHEBUST=1
+RUN zypper --non-interactive refresh; zypper lr --details
+

--- a/Dockerfile.sles.12.3
+++ b/Dockerfile.sles.12.3
@@ -13,7 +13,6 @@ ARG UID=1000
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build
-ENV PASSWD build
 RUN useradd -u $UID -ms /bin/bash $USER
 RUN groupadd -g $UID $USER
 
@@ -37,6 +36,7 @@ RUN echo "#includedir /etc/sudoers.d" >> /etc/sudoers; \
     echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build
 
 # Suse build utility needs this refresh.
+# And the zypper lr report is handy to have.
 ARG CACHEBUST=1
 RUN zypper --non-interactive refresh; zypper lr --details
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,19 +60,15 @@ pipeline {
                             filename 'Dockerfile.sles.12.3'
                             label 'docker_runner'
                             args '--privileged=true'
-                            additionalBuildArgs '--build-arg UID=$(id -u)'
+                            additionalBuildArgs '--build-arg UID=$(id -u)' +
+                                                ' --build-arg CACHEBUST=' +
+                                                currentBuild.startTimeInMillis
                         }
                     }
                     steps {
                         sh '''rm -rf artifacts/sles12.3/
                               mkdir -p artifacts/sles12.3/
-                              make source
-                              sudo build \
-                                --repo http://cobbler/cobbler/ks_mirror/SLES-12.3-x86_64/suse \
-                                --repo http://cobbler/cobbler/repo_mirror/sdk-sles12.3-x86_64 \
-                                --repo http://cobbler/cobbler/repo_mirror/updates-sles12.3-x86_64 \
-                                --repo http://cobbler/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64 \
-                                --dist sles12.3'''
+                              make mockbuild'''
                     }
                     post {
                         success {
@@ -103,17 +99,15 @@ pipeline {
                             filename 'Dockerfile.leap.42.3'
                             label 'docker_runner'
                             args '--privileged=true'
-                            additionalBuildArgs '--build-arg UID=$(id -u)'
+                            additionalBuildArgs '--build-arg UID=$(id -u)' +
+                                                ' --build-arg CACHEBUST=' +
+                                                currentBuild.startTimeInMillis
                         }
                     }
                     steps {
                         sh '''rm -rf artifacts/leap42.3/
                               mkdir -p artifacts/leap42.3/
-                              make source
-                              sudo build \
-                                --repo http://download.opensuse.org/update/leap/42.3/oss/ \
-                                --repo http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/ \
-                                --dist sl42.3'''
+                              make mockbuild'''
                     }
                     post {
                         success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
                     steps {
                         sh '''rm -rf artifacts/sles12.3/
                               mkdir -p artifacts/sles12.3/
-                              make mockbuild'''
+                              make chrootbuild'''
                     }
                     post {
                         success {
@@ -107,7 +107,7 @@ pipeline {
                     steps {
                         sh '''rm -rf artifacts/leap42.3/
                               mkdir -p artifacts/leap42.3/
-                              make mockbuild'''
+                              make chrootbuild'''
                     }
                     post {
                         success {

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -78,19 +78,19 @@ _topdir/SOURCES/%: % | _topdir/SOURCES/
 	ln $< $@
 
 $(NAME)-$(VERSION).tar.$(SRC_EXT).asc: $(NAME).spec Makefile
-	rm -f $(NAME)-$(VERSION).tar.{gz,bz*,xz}.asc
+	rm -f ./$(NAME)-*.tar.{gz,bz*,xz}.asc
 	curl -f -L -O '$(SOURCE).asc'
 
 $(NAME)-$(VERSION).tar.$(SRC_EXT): $(NAME).spec Makefile
-	rm -f $(NAME)-$(VERSION).tar.{gz,bz*,xz}
+	rm -f ./$(NAME)-*.tar.{gz,bz*,xz}
 	curl -f -L -O '$(SOURCE)'
 
 v$(VERSION).tar.$(SRC_EXT): $(NAME).spec Makefile
-	rm -f v$(VERSION).tar.{gz,bz*,xz}
+	rm -f ./v*.tar.{gz,bz*,xz}
 	curl -f -L -O '$(SOURCE)'
 
 $(VERSION).tar.$(SRC_EXT): $(NAME).spec Makefile
-	rm -f $(VERSION).tar.{gz,bz*,xz}
+	rm -f ./*.tar.{gz,bz*,xz}
 	curl -f -L -O '$(SOURCE)'
 
 $(DEB_TOP)/%: % | $(DEB_TOP)/
@@ -209,11 +209,11 @@ ls: $(TARGETS)
 	ls -ld $^
 
 ifneq ($(ID_LIKE),suse)
-mockbuild: $(SRPM)  Makefile
+chrootbuild: $(SRPM)  Makefile
 
 	mock $(MOCK_OPTIONS) $(RPM_BUILD_OPTIONS) $<
 else
-mockbuild: Makefile $(SOURCES)
+chrootbuild: Makefile $(SOURCES)
 	sudo build --repo zypp:// --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS)
 endif
 
@@ -246,6 +246,6 @@ show_sources:
 show_targets:
 	@echo $(TARGETS)
 
-.PHONY: srpm rpms debs ls mockbuild rpmlint FORCE \
+.PHONY: srpm rpms debs ls chrootbuild rpmlint FORCE \
         show_version show_release show_rpms show_source show_sources \
         show_targets check-env

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -9,7 +9,23 @@
 ifeq ($(DEB_NAME),)
 DEB_NAME := $(NAME)
 endif
+
+# Find out what we are
 ID_LIKE := $(shell . /etc/os-release; echo $$ID_LIKE)
+# Of course that does not work for SLES-12
+ID := $(shell . /etc/os-release; echo $$ID)
+VERSION_ID := $(shell . /etc/os-release; echo $$VERSION_ID)
+ifeq ($(findstring opensuse,$(ID)),opensuse)
+ID_LIKE := suse
+DISTRO_ID := sl$(VERSION_ID)
+endif
+ifeq ($(ID),sles)
+# SLES-12 or 15 detected.
+ID_LIKE := suse
+DISTRO_ID := sle$(VERSION_ID)
+endif
+
+
 COMMON_RPM_ARGS := --define "%_topdir $$PWD/_topdir"
 DIST    := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 ifeq ($(DIST),)
@@ -26,16 +42,12 @@ DEB_VERS := $(subst rc,~rc,$(VERSION))
 DEB_RVERS := $(subst $(DOT),\$(DOT),$(DEB_VERS))
 DEB_BVERS := $(basename $(subst ~rc,$(DOT)rc,$(DEB_VERS)))
 RELEASE := $(shell rpm $(COMMON_RPM_ARGS) --specfile --qf '%{release}\n' $(SPEC) | sed -n '$(SED_EXPR)')
-SRPM    ?= _topdir/SRPMS/$(NAME)-$(VERSION)-$(RELEASE)$(DIST).src.rpm
-ifeq ($(RPMS),)
+SRPM    := _topdir/SRPMS/$(NAME)-$(VERSION)-$(RELEASE)$(DIST).src.rpm
 RPMS    := $(addsuffix .rpm,$(addprefix _topdir/RPMS/x86_64/,$(shell rpm --specfile $(SPEC))))
-endif
 DEB_TOP := _topdir/BUILD
 DEB_BUILD := $(DEB_TOP)/$(NAME)-$(DEB_VERS)
 DEB_TARBASE := $(DEB_TOP)/$(DEB_NAME)_$(DEB_VERS)
-ifeq ($(SOURCES),)
 SOURCES := $(addprefix _topdir/SOURCES/,$(notdir $(SOURCE)) $(PATCHES))
-endif
 ifeq ($(ID_LIKE),debian)
 DEBS    := $(addsuffix _$(DEB_VERS)-1_amd64.deb,$(shell sed -n '/-udeb/b; s,^Package:[[:blank:]],$(DEB_TOP)/,p' debian/control))
 CLEAN_TARBALS := $(shell rm -f *.tar.$(SRC_EXT))
@@ -65,16 +77,20 @@ _topdir/SOURCES/%: % | _topdir/SOURCES/
 	rm -f $@
 	ln $< $@
 
-$(NAME)-$(VERSION).tar.$(SRC_EXT).asc:
+$(NAME)-$(VERSION).tar.$(SRC_EXT).asc: $(NAME).spec Makefile
+	rm -f $(NAME)-$(VERSION).tar.{gz,bz*,xz}.asc
 	curl -f -L -O '$(SOURCE).asc'
 
-$(NAME)-$(VERSION).tar.$(SRC_EXT):
+$(NAME)-$(VERSION).tar.$(SRC_EXT): $(NAME).spec Makefile
+	rm -f $(NAME)-$(VERSION).tar.{gz,bz*,xz}
 	curl -f -L -O '$(SOURCE)'
 
-v$(VERSION).tar.$(SRC_EXT):
+v$(VERSION).tar.$(SRC_EXT): $(NAME).spec Makefile
+	rm -f v$(VERSION).tar.{gz,bz*,xz}
 	curl -f -L -O '$(SOURCE)'
 
-$(VERSION).tar.$(SRC_EXT):
+$(VERSION).tar.$(SRC_EXT): $(NAME).spec Makefile
+	rm -f $(VERSION).tar.{gz,bz*,xz}
 	curl -f -L -O '$(SOURCE)'
 
 $(DEB_TOP)/%: % | $(DEB_TOP)/
@@ -176,14 +192,12 @@ $(subst deb,%,$(DEBS)): $(DEB_BUILD).tar.$(SRC_EXT) \
 	for f in $(DEB_TOP)/*.deb; do \
 	  echo $$f; dpkg -c $$f; done
 
-ifneq ($(SRC_EXT),rpm)
 $(SRPM): $(SPEC) $(SOURCES)
-	rpmbuild -bs $(COMMON_RPM_ARGS) $(SPEC)
-endif
+	rpmbuild -bs $(COMMON_RPM_ARGS) $(RPM_BUILD_OPTIONS) $(SPEC)
 
 srpm: $(SRPM)
 
-$(RPMS): Makefile
+$(RPMS): $(SRPM) Makefile
 
 rpms: $(RPMS)
 
@@ -194,15 +208,17 @@ debs: $(DEBS)
 ls: $(TARGETS)
 	ls -ld $^
 
-mockbuild: $(SRPM) Makefile
-	mock $(MOCK_OPTIONS) $<
+ifneq ($(ID_LIKE),suse)
+mockbuild: $(SRPM)  Makefile
+
+	mock $(MOCK_OPTIONS) $(RPM_BUILD_OPTIONS) $<
+else
+mockbuild: Makefile $(SOURCES)
+	sudo build --repo zypp:// --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS)
+endif
 
 rpmlint: $(SPEC)
 	rpmlint $<
-
-# Debian wants a distclean target
-#distclean:
-#	@echo "distclean"
 
 check-env:
 ifndef DEBEMAIL
@@ -215,9 +231,6 @@ endif
 show_version:
 	@echo $(VERSION)
 
-show_tag:
-	@echo ${TAG}
-
 show_release:
 	@echo $(RELEASE)
 
@@ -226,9 +239,6 @@ show_rpms:
 
 show_source:
 	@echo $(SOURCE)
-	@echo -$(NAME)-$(VERSION).tar.$(SRC_EXT)-
-
-source: $(notdir $(SOURCE))
 
 show_sources:
 	@echo $(SOURCES)
@@ -236,6 +246,6 @@ show_sources:
 show_targets:
 	@echo $(TARGETS)
 
-.PHONY: srpm rpms debs ls mockbuild rpmlint FORCE show_version show_tag \
-     show_release show_rpms source show_source show_sources show_targets \
-     check-env
+.PHONY: srpm rpms debs ls mockbuild rpmlint FORCE \
+        show_version show_release show_rpms show_source show_sources \
+        show_targets check-env


### PR DESCRIPTION
Add the repositories to the Dockerfile and move the suse
build command to the Makefile.

Signed-off-by: John.E.Malmberg <john.e.malmberg@intel.com>